### PR TITLE
Make LICENSE.txt a Unicode file

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Pavel Rosický
+Copyright (c) 2020 Pavel RosickÃ½
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -77,7 +77,7 @@ https://github.com/mishoo/UglifyJS
           disclaimer in the documentation and/or other materials
           provided with the distribution.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER “AS IS” AND ANY
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER "AS IS" AND ANY
     EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
     IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
     PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE


### PR DESCRIPTION
Right now, LICENSE.txt is a non-ISO ASCII file, causing GitHub's raw view to make it look weird - https://raw.githubusercontent.com/ahorek/terser-ruby/master/LICENSE.txt.

This PR makes it a Unicode file, so this doesn't happen - https://raw.githubusercontent.com/balasankarc/terser-ruby/master/LICENSE.txt