### PR TITLE
workflows badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ a fork based on https://github.com/lautis/uglifier and https://github.com/mishoo
 
 ES6 support
 
-[![Build Status](https://api.travis-ci.com/ahorek/terser-ruby.svg?branch=master)](https://travis-ci.com/ahorek/terser-ruby)
+[![Ruby](https://github.com/ahorek/terser-ruby/actions/workflows/ruby.yml/badge.svg)](https://github.com/ahorek/terser-ruby/actions/workflows/ruby.yml)
 
 ### Rails
 


### PR DESCRIPTION
updates the badge, because I moved away from travis ci to github actions.

fixes https://github.com/ahorek/terser-ruby/issues/17