### PR TITLE
Fix to run CI with Ruby 3.0

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -18,7 +18,7 @@ jobs:
         include:
           - { ruby: 2.3, c-o-e: false }
           - { ruby: 2.7, c-o-e: false }
-          - { ruby: 3.0, c-o-e: false }
+          - { ruby: '3.0', c-o-e: false }
           - { ruby: 3.1, c-o-e: false }
           - { ruby: jruby-9.4.0.0, c-o-e: false }
           - { ruby: ruby-head, c-o-e: true }
@@ -27,7 +27,7 @@ jobs:
           - { ruby: truffleruby-head, c-o-e: true }
           - { ruby: 3.1, gemfile: ./gemfiles/miniracer, c-o-e: false }
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
Using 3.0 without quotes, `ruby/setup-ruby` will use 3.1 instead of 3.0.
Please see the following for more details.
- https://github.com/ruby/setup-ruby/issues/252
- https://github.com/actions/runner/issues/849

[actions/checkout](https://github.com/actions/checkout) were also bumped from v2 to v3 to suppress the following warning.
> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2