### PR TITLE
Enable passing terser options with rails directly to Terser::Compressor

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ Rails.application.configure do
   config.assets.js_compressor = :terser
 end
 ```
+
+Passing terser options
+
+```ruby
+Rails.application.configure do
+  config.assets.terser = { compress: { drop_console: true } }
+end
+```
+
 in `config/environments/production.rb`.
 
 ## Installation
@@ -80,8 +89,8 @@ Available options and their defaults are
     :indent_start => 0,         # Starting indent level
     :width => 80,               # Specify line width when beautifier is used (only with beautifier)
     :preamble => nil,           # Preamble for the generated JS file. Can be used to insert any code or comment.
-    :wrap_iife => false         # Wrap IIFEs in parenthesis. Note: this disables the negate_iife compression option.
-    :shebang => true            # Preserve shebang (#!) in preamble (shell scripts)
+    :wrap_iife => false,        # Wrap IIFEs in parenthesis. Note: this disables the negate_iife compression option.
+    :shebang => true,           # Preserve shebang (#!) in preamble (shell scripts)
     :quote_style => 0,          # Quote style, possible values :auto (default), :single, :double, :original
     :keep_quoted_props => false # Keep quotes property names
   },
@@ -97,7 +106,7 @@ Available options and their defaults are
     :regex => nil,              # A regular expression to filter property names to be mangled
     :ignore_quoted => false,    # Only mangle unquoted property names
     :debug => false,            # Mangle names with the original name still present
-  }                             # Mangle property names, disabled by default
+  },                            # Mangle property names, disabled by default
   :compress => {
     :sequences => true,         # Allow statements to be joined by commas
     :properties => true,        # Rewrite property access using the dot notation

--- a/lib/terser/compressor.rb
+++ b/lib/terser/compressor.rb
@@ -10,7 +10,7 @@ class Terser
 
     def initialize(options = {})
       options[:comments] ||= :none
-      @options = options
+      @options = options.merge(Rails.application.config.assets.terser.to_h)
       @cache_key = -"Terser:#{::Terser::VERSION}:#{VERSION}:#{::Sprockets::DigestUtils.digest(options)}"
       @terser = ::Terser.new(@options)
     end


### PR DESCRIPTION
## Purpose

Add a way to pass options to the terser compressor when using rails.

### Existing way:

`config.assets.js_compressor = Terser.new(compress: { drop_console: true })`

The problem with this way of passing options is that bypasses the Terser::Compressor class and uses directly `Terser#compile` since there is an [alias](https://github.com/javier-menendez/terser-ruby/blob/496f3678af6bdb35de934672e7a6516b20d5229a/lib/terser.rb#L172) for compress

### Proposed new way:

```
config.assets.js_compressor = :terser
config.assets.terser = { compress: { drop_console: true } }
```

This way the Terser::Compressor is going to be used with their `call` methods according to the Sprockets version

