### PR TITLE
Mangle Properties Fix

### DIFF
--- a/lib/terser_wrapper.js
+++ b/lib/terser_wrapper.js
@@ -1,6 +1,8 @@
 // Set source-map.js sourceMap to terser.js MOZ_SourceMap
 MOZ_SourceMap = sourceMap;
 
+var global = global || {};
+
 function comments(option) {
   if (Object.prototype.toString.call(option) === '[object Array]') {
     return new RegExp(option[0], option[1]);

--- a/spec/terser_spec.rb
+++ b/spec/terser_spec.rb
@@ -46,48 +46,47 @@ describe "Terser" do
     expect(Terser.new.compile('var foo="\0bar"')).to include("\\0bar")
   end
 
-  # TODO: fixme
-  #  describe "property name mangling" do
-  #    let(:source) do
-  #      <<-JS
-  #       var obj = {
-  #          _hidden: false,
-  #          "quoted": 'value'
-  #        };
-  #
-  #        alert(object.quoted);
-  #      JS
-  #    end
-  #
-  #    it "does not mangle property names by default" do
-  #      expect(Terser.compile(source)).to include("object.quoted")
-  #    end
-  #
-  #    it "can be configured to mangle properties" do
-  #      expect(Terser.compile(source, :mangle => { :properties => true }))
-  #        .not_to include("object.quoted")
-  #    end
-  #
-  #    it "can be configured using old mangle_properties" do
-  #      expect(Terser.compile(source, :mangle_properties => true))
-  #        .not_to include("object.quoted")
-  #    end
-  #
-  #    it "can configure a regex for mangling" do
-  #      expect(Terser.compile(source, :mangle => { :properties => { :regex => /^_/ } }))
-  #        .to include("object.quoted")
-  #    end
-  #
-  #    it "can be configured to keep quoted properties" do
-  #      expect(Terser.compile(source, :mangle => { :properties => { :keep_quoted => true } }))
-  #        .to include("object.quoted")
-  #    end
-  #
-  #    it "can be configured to include debug in mangled properties" do
-  #      expect(Terser.compile(source, :mangle => { :properties => { :debug => true } }))
-  #        .to include("_$quoted$_")
-  #    end
-  #  end
+  describe "property name mangling" do
+    let(:source) do
+      <<-JS
+       var obj = {
+          _hidden: false,
+          "quoted": 'value'
+        };
+
+        alert(object.quoted);
+      JS
+    end
+
+    it "does not mangle property names by default" do
+      expect(Terser.compile(source)).to include("object.quoted")
+    end
+
+    it "can be configured to mangle properties" do
+      expect(Terser.compile(source, :mangle => { :properties => true }))
+        .not_to include("object.quoted")
+    end
+
+    it "can be configured using old mangle_properties" do
+      expect(Terser.compile(source, :mangle_properties => true))
+        .not_to include("object.quoted")
+    end
+
+    it "can configure a regex for mangling" do
+      expect(Terser.compile(source, :mangle => { :properties => { :regex => /^_/ } }))
+        .to include("object.quoted")
+    end
+
+    it "can be configured to keep quoted properties" do
+      expect(Terser.compile(source, :mangle => { :properties => { :keep_quoted => true } }))
+        .to include("object.quoted")
+    end
+
+    it "can be configured to include debug in mangled properties" do
+      expect(Terser.compile(source, :mangle => { :properties => { :debug => true } }))
+        .to include("_$quoted$_")
+    end
+  end
 
   describe "argument name mangling" do
     let(:code) { "function bar(foo) {return foo + 'bar'};" }


### PR DESCRIPTION
Terser would not process any scripts when the `mangle_properties` config was set. This was due to a problem with the Terser library expecting the `global` variable to be defined, which it is in a normal NodeJS environment, but unfortunately in an ExecJS abstract context it is stripped out presumable to provide consistency with other Javascript runners.

The fix I implemented is to check for the presence of `global` and if not set, set it.

```js
var global = global || {};
```

This should not break anything, and now all processing completes and the specs pass.