### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/terser

### DIFF
--- a/terser.gemspec
+++ b/terser.gemspec
@@ -35,4 +35,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "sourcemap", "~> 0.1.1"
+
+  spec.metadata["changelog_uri"] = spec.homepage + "/blob/master/CHANGELOG.md"
 end


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/terser which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/