### PR TITLE
Link from CHANGELOG.md to TerserJS CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+Behavioural changes in TerserJS are listed [here](https://github.com/terser/terser/blob/master/CHANGELOG.md).
+
 ## Unreleased
 ## 1.2.0 (22 January 2024)
 - update TerserJS to [5.27.0]


### PR DESCRIPTION
Thank you Pavel. As you noted on my previous [PR](https://github.com/ahorek/terser-ruby/pull/51#issuecomment-1912471774) behavioural changes will be documented in the TerserJS repository. I think it makes sense to provide a link to that from the CHANGELOG.md in this repository