### PR TITLE
Package an unminified version of terser

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -59,9 +59,7 @@ namespace :terser do
 
     FileUtils.cp("vendor/source-map/dist/source-map.min.js", "lib/source-map.js")
 
-    # FileUtils.cp("vendor/terser/dist/bundle.min.js", "lib/terser.js")
-    minified_source = `node ./vendor/terser/bin/terser vendor/terser/dist/bundle.min.js`
-    File.write("lib/terser.js", minified_source)
+    FileUtils.cp("vendor/terser/dist/bundle.min.js", "lib/terser.js")
 
     FileUtils.cp("vendor/split/split.js", "lib/split.js")
     `patch -p1 -i patches/es5-string-split.patch`


### PR DESCRIPTION
This started in https://github.com/ahorek/terser-ruby/pull/4 but couldn't see a reason why.

Minification makes it harder to debug issues and also makes it much harder to review the gem changes on upgrade.

AFAIK this gem is only used with `exec-js` for which minification doesn't impact performance much.